### PR TITLE
Pass grunt into callbacks

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -280,7 +280,7 @@ module.exports = function(grunt) {
       config = grunt.config.get(['esteWatch', '*']);
     if (!config)
       return [];
-    var tasks = config(filepath) || [];
+    var tasks = config(filepath, grunt) || [];
     if (!Array.isArray(tasks))
       tasks = [tasks];
     return tasks;


### PR DESCRIPTION
Update passes grunt into the callbacks as the callbacks are not always defined within context of the grunt configuration.