### PR TITLE
Rerun watch task as it was originally called

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -159,7 +159,7 @@ module.exports = function(grunt) {
 
   var rerun = function() {
     grunt.task.clearQueue();
-    grunt.task.run('esteWatch');
+    grunt.task.run(grunt.task.current.nameArgs);
   };
 
   var dispatchWaitingChanges = function() {
@@ -249,7 +249,7 @@ module.exports = function(grunt) {
     var tasks = getFilepathTasks(filepath);
     if (options.livereload.enabled)
       tasks.push('esteWatchLiveReload');
-    tasks.push('esteWatch');
+    tasks.push(grunt.task.current.nameArgs);
 
     var waitTryCount = 0;
     var waitForFileUnlock = function() {


### PR DESCRIPTION
This change will restart the task as it was originally called. IE, `$ grunt esteWatch:foobar` will start the next loop as `esteWatch:foobar` instead of resetting to just `esteWatch`.